### PR TITLE
Inputs/tref

### DIFF
--- a/src/grins_interface/include/planet/planet_physics_helper.h
+++ b/src/grins_interface/include/planet/planet_physics_helper.h
@@ -260,7 +260,7 @@ namespace Planet
       _ionic_reaction_set(NULL),
       _chapman(NULL),
       _tau(NULL),
-      _scaling_factor(-1.L),
+      _scaling_factor(-1),
       _explicit_first_guess(false)
   {
     this->build(input);
@@ -359,7 +359,8 @@ namespace Planet
   void PlanetPhysicsHelper<CoeffType,VectorCoeffType,MatrixCoeffType>::build(const GetPot& input)
   {
     // Let's start with the scaling factor
-    _scaling_factor = input("Planet/scale_factor", -1);
+    if(input.have_variable("Planet/scale_factor") )
+       _scaling_factor = input("Planet/scale_factor", -1);
 
 
     // Parse medium

--- a/src/grins_interface/include/planet/planet_physics_helper.h
+++ b/src/grins_interface/include/planet/planet_physics_helper.h
@@ -359,7 +359,7 @@ namespace Planet
   void PlanetPhysicsHelper<CoeffType,VectorCoeffType,MatrixCoeffType>::build(const GetPot& input)
   {
     // Let's start with the scaling factor
-    _scaling_factor = input("Planet/scale_factor", -1.);
+    _scaling_factor = input("Planet/scale_factor", -1);
 
 
     // Parse medium
@@ -626,7 +626,7 @@ namespace Planet
     CoeffType Tref(1);
     if( input.have_variable("Planet/Kooij_Tref") )
       {
-         Tref = input("Planet/Kooij_Tref","1");
+         Tref = input("Planet/Kooij_Tref",1);
       }
     this->fill_neutral_reactions_elementary(input_reactions_elem, *_neutral_reaction_set, Tref);
 
@@ -692,7 +692,7 @@ namespace Planet
     _composition->set_thermal_coefficient(tc);
     _composition->set_hard_sphere_radius(hard_sphere_radius);
 
-    if(_scaling_factor < 0.)_scaling_factor = dens_tot;
+    if(_scaling_factor < 0)_scaling_factor = dens_tot;
 
     return;
   }


### PR DESCRIPTION
Reference temperature for Hercourt-Essen and derived kinetics model is setable through the input file.

Note that elementary and falloff kinetics model should have the same reference temperature.

**Note:** to be merged after PR#10